### PR TITLE
[Mellanox] Added persistent MLOOP configuration script 

### DIFF
--- a/debian/syncd.install
+++ b/debian/syncd.install
@@ -5,4 +5,5 @@ usr/bin/saidiscovery
 usr/bin/saiasiccmp
 usr/bin/syncd*
 syncd/scripts/* usr/bin
+syncd/scripts/persistent_mloop.conf etc/supervisor/conf.d
 usr/lib/*/libMdioIpcClient.so.*

--- a/syncd/scripts/persistent_mloop.conf
+++ b/syncd/scripts/persistent_mloop.conf
@@ -1,0 +1,6 @@
+[program:persistent_mloop]
+command=python3 /usr/bin/persistent_mloop.py
+stdout_logfile=/tmp/mloop.out.log
+stderr_logfile=/tmp/mloop.err.log
+autostart=true
+autorestart=false

--- a/syncd/scripts/persistent_mloop.conf
+++ b/syncd/scripts/persistent_mloop.conf
@@ -1,5 +1,6 @@
 [program:persistent_mloop]
 command=python3 /usr/bin/persistent_mloop.py
+priority=50
 stdout_logfile=/tmp/mloop.out.log
 stderr_logfile=/tmp/mloop.err.log
 autostart=true

--- a/syncd/scripts/persistent_mloop.conf
+++ b/syncd/scripts/persistent_mloop.conf
@@ -1,7 +1,9 @@
 [program:persistent_mloop]
 command=python3 /usr/bin/persistent_mloop.py
 priority=50
-stdout_logfile=/tmp/mloop.out.log
-stderr_logfile=/tmp/mloop.err.log
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
 autostart=true
 autorestart=false

--- a/syncd/scripts/persistent_mloop.py
+++ b/syncd/scripts/persistent_mloop.py
@@ -74,6 +74,8 @@ class MloopConfig:
 
         for line in port_table:
             line = line.split()
+            if len(line) < 3:
+                continue
             self.port_translation[line[1]] = line[2]
 
         self.port_translation = dict(sorted(self.port_translation.items(), key=port_sorting))
@@ -98,7 +100,7 @@ class MloopConfig:
                 if retries < 10:
                     print("Retrying to config {0}".format(logical_port))
                 else:
-                    print("Failed to config {0}".format(logical_port)
+                    print("Failed to config {0}".format(logical_port))
                 time.sleep(10)
                 continue
 
@@ -131,8 +133,14 @@ class MloopConfig:
 
     def read_saved_ports(self):
         full_path = os.path.join(CONFIGURED_PORTS_PATH, CONFIGURED_PORTS_FILE)
+
+        if not os.path.exists(full_path):
+            return False
+
         with open(full_path, 'r') as ports_file:
             self.ports = json.load(ports_file)
+
+        return True
         
 
 def main():
@@ -158,6 +166,9 @@ def main():
             print(f"Error while copying {SERVICE_FILE} to {SERVICE_PATH}: {e}")
 
     mloopconfig = MloopConfig()
+    if not mloopconfig.port_translation:
+        print("Failed to parse ports from SDK file")
+        return
 
     if args.port_range:
         mloopconfig.config_range(args.port_range)
@@ -166,7 +177,9 @@ def main():
         mloopconfig.config_ports(args.ports)
         mloopconfig.save_mloop_ports()
     else:
-        mloopconfig.read_saved_ports()
+        if not mloopconfig.read_saved_ports():
+            print("No port to configure")
+            return
         mloopconfig.config_ports()
 
 

--- a/syncd/scripts/persistent_mloop.py
+++ b/syncd/scripts/persistent_mloop.py
@@ -51,7 +51,7 @@ class MloopConfig:
         for logical_port in logical_ports:
             self.config_port_to_mloop(logical_port)
 
-        self.save_mloop_ports()
+        self.save_config()
     
     def build_translation_dict(self):
         self.port_translation = {}
@@ -91,7 +91,8 @@ class MloopConfig:
                         shell=False, stdout=subprocess.PIPE, text=True)
         while (not configured) and (retries < MAX_RETRIES):
             try:
-                check_output_pipe(["echo", "y"], ["sx_api_port_tx_signal_set.py", "--log_port", logical_port, "--state", "up"])      
+                if self.loopback_type != 0:
+                    check_output_pipe(["echo", "y"], ["sx_api_port_tx_signal_set.py", "--log_port", logical_port, "--state", "up"])      
                 configured = True
             except:
                 retries += 1

--- a/syncd/scripts/persistent_mloop.py
+++ b/syncd/scripts/persistent_mloop.py
@@ -31,12 +31,6 @@ class MloopConfig:
         if ports:
             self.ports = ports
 
-        # The first time doesn't work for some reason
-        first_port = self.port_translation.get(self.ports[0])
-
-        if first_port:
-            self.config_port_to_mloop(first_port)
-
         for port in self.ports:
             logical_port = self.port_translation.get(port)
 
@@ -152,7 +146,6 @@ def check_switch_init():
     result = subprocess.run(["sonic-db-cli", "APPL_DB", "EXISTS", "PORT_TABLE:PortInitDone"], 
                             shell=False, capture_output=True, text=True)
 
-    print(result.stdout.strip())
     return result.stdout.strip() == "1"
         
 

--- a/syncd/scripts/persistent_mloop.py
+++ b/syncd/scripts/persistent_mloop.py
@@ -1,0 +1,168 @@
+import json
+import argparse
+import subprocess
+import time
+import shutil
+import os.path
+from sonic_py_common.general import check_output_pipe
+
+CONFIGURED_PORTS_PATH = "/etc/mloop_conf/"
+CONFIGURED_PORTS_FILE = "mloop_ports.json"
+SAISDKDUMP_PATH = "/saisdkdump_file"
+SERVICE_FILE = "persistent_mloop.conf"
+SERVICE_PATH = "/etc/supervisor/conf.d/"
+
+def port_sorting(port):
+    """
+    For translation dict sorting. Returns the port number in port name.
+    """
+    return int(port[0][len("Ethernet"):]) if "Ethernet" in port[0] else 0
+
+class MloopConfig:
+    def __init__(self):
+        self.ports = []
+        self.build_translation_dict()
+
+    def config_ports(self, ports=None):
+        configured_ports = []
+
+        if ports:
+            self.ports = ports
+
+        # The first time doesn't work for some reason
+        first_port = self.port_translation.get(self.ports[0])
+        self.config_port_to_mloop(first_port)
+
+        for port in self.ports:
+            logical_port = self.port_translation.get(port)
+
+            if not logical_port:
+                print(f"{port} doesn't exist")
+                continue
+
+            self.config_port_to_mloop(logical_port)
+            configured_ports.append(port)
+
+    def config_range(self, port_range):
+        logical_ports = self.parse_range(port_range)
+
+        if not logical_ports:
+            return
+        
+        for logical_port in logical_ports:
+            self.config_port_to_mloop(logical_port)
+
+        self.save_mloop_ports()
+    
+    def build_translation_dict(self):
+        self.port_translation = {}
+
+        if not os.path.exists(SAISDKDUMP_PATH):
+            subprocess.run(["saisdkdump", "-f", SAISDKDUMP_PATH], shell=False, stdout=subprocess.PIPE, text=True)
+
+        with open(SAISDKDUMP_PATH, 'r') as saisdk_file:
+            dump_lines = saisdk_file.read()
+
+        start_index = dump_lines.find("netdev_dump")
+        end_index = dump_lines.find("cmd_ifc_dump")
+
+        port_table = dump_lines[start_index:end_index]
+        port_table = port_table.split('\n')
+        port_table = port_table[4:]
+
+        for line in port_table:
+            line = line.split()
+            self.port_translation[line[1]] = line[2]
+
+        self.port_translation = dict(sorted(self.port_translation.items(), key=port_sorting))
+        
+    def save_mloop_ports(self):
+        os.makedirs(CONFIGURED_PORTS_PATH, exist_ok=True)
+        full_path = os.path.join(CONFIGURED_PORTS_PATH, CONFIGURED_PORTS_FILE)
+        with open(full_path, 'w') as ports_file:
+            json.dump(self.ports, ports_file)
+
+    def config_port_to_mloop(self, logical_port):
+        configured = False
+        retries = 0    
+        subprocess.run(["sx_api_port_phys_loopback.py", "--cmd", "0", "--log_port", logical_port, "--loopback_type", "2", "--force" ], 
+                        shell=False, stdout=subprocess.PIPE, text=True)
+        while (not configured) and (retries < 500):
+            try:
+                check_output_pipe(["echo", "y"], ["sx_api_port_tx_signal_set.py", "--log_port", logical_port, "--state", "up"])      
+                configured = True
+            except:
+                print("Retrying to config {0}".format(logical_port))
+                retries += 1
+                time.sleep(10)
+                continue
+
+    def parse_range(self, port_range):
+        found_first = False
+        found_last = False
+        logical_ports = []
+
+        for port, logical_port in self.port_translation.items():
+            if port == port_range[0]:
+                found_first = True
+
+            if found_first and not found_last:
+                logical_ports.append(logical_port)
+                self.ports.append(port)
+            elif found_last and not found_first:
+                print("Error: invalid range - end port found before start port")
+
+            if port == port_range[1]:
+                found_last = True
+                break
+
+        if not found_first or (found_first and not found_last):
+            port = port_range[0] if not found_first else port_range[1]
+            print(f"Error: invalid range - {port} doesn't exist")
+            return None
+
+        return logical_ports
+
+    def read_saved_ports(self):
+        full_path = os.path.join(CONFIGURED_PORTS_PATH, CONFIGURED_PORTS_FILE)
+        with open(full_path, 'r') as ports_file:
+            self.ports = json.load(ports_file)
+        
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ports", nargs="+", type=str, help="List of ports to be configured to mloop, in the following format: port1 port2 ...")
+    parser.add_argument("--port-range", nargs=2, help="Range of ports to be configured to mloop, in the following format: <start_port> <end_port>")
+    args = parser.parse_args()
+
+    if args.ports and args.port_range:
+        print("Error: must specify only one of the options - PORTS or PORT-RANGE")
+        return 
+
+    service_file_path = os.path.join(SERVICE_PATH, SERVICE_FILE)
+    if not os.path.exists(service_file_path):
+        current_dir_file_path = os.path.join(os.getcwd(), SERVICE_FILE)
+        if not os.path.exists(current_dir_file_path):
+            print(f"Error: {SERVICE_FILE} is not found in {SERVICE_PATH} or the current directory.")
+            return
+    
+        try:
+            shutil.copy(current_dir_file_path, SERVICE_PATH)
+        except Exception as e:
+            print(f"Error while copying {SERVICE_FILE} to {SERVICE_PATH}: {e}")
+
+    mloopconfig = MloopConfig()
+
+    if args.port_range:
+        mloopconfig.config_range(args.port_range)
+
+    elif args.ports:
+        mloopconfig.config_ports(args.ports)
+        mloopconfig.save_mloop_ports()
+    else:
+        mloopconfig.read_saved_ports()
+        mloopconfig.config_ports()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Verification team need the ability to configure ports to MLOOP persistently, so the configuration stays after reloads and upgrades.
Added a script to syncd docker called persistent_mloop.py and a service that runs it when there are ports configured with it.
To use the script:
python /usr/bin/persistent_mloop.py --ports <port_list>
python /usr/bin/persistent_mloop.py --port-range <first_port> <last_port>
